### PR TITLE
Update Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,7 +1,7 @@
 Vagrant.configure("2") do |config|
 
   config.vm.box = "hashicorp/bionic64"  
-  config.vm.network "forwarded_port", guest: 80, host: 8888  
+  config.vm.network "forwarded_port", guest: 80, host: 8080  
 
   config.vm.provision "shell", inline: <<-SHELL
 


### PR DESCRIPTION
Requerimiento: Redirigir el tráfico web de la VM al puerto 8080 de la máquina Host (su propia computadora).